### PR TITLE
Add sequence to example output in line with BCOP examples

### DIFF
--- a/icalendar/icalendar-example.py
+++ b/icalendar/icalendar-example.py
@@ -51,6 +51,7 @@ event = xmaintnote.XMaintNoteEvent()
 
 event.add('summary', 'Maint Note Example')
 event.add('uid', '42')
+event.add('sequence', 1)
 #event.add('dtstart', datetime(2015, 10, 10, 8, 0, 0, tzinfo=pytz.utc))
 #event.add('dtend', datetime(2015, 10, 10, 10, 0, 0, tzinfo=pytz.utc))
 #event.add('dtstamp', datetime(2015, 10, 10, 0, 10, 0, tzinfo=pytz.utc))

--- a/icalendar/xmaintnote.py
+++ b/icalendar/xmaintnote.py
@@ -1,7 +1,10 @@
 import icalendar
 from icalendar import Event, vText
 
-import simplejson as _json
+try:
+    import simplejson as _json
+except ImportError:
+    import json as _json
 
 import re
 


### PR DESCRIPTION
Worked on as part of NANOG67 hackathon

This PR also reduces external dependencies for xmaintnote module by adding stdlib json if simplejson not available.
