### PR TITLE
Custom values for X-MAINTNOTE-IMPACT should be allowed.

### DIFF
--- a/icalendar/icalendar-example.py
+++ b/icalendar/icalendar-example.py
@@ -1,3 +1,4 @@
+import logging
 from icalendar import Calendar, Event
 from icalendar import vCalAddress, vText
 
@@ -6,7 +7,7 @@ import xmaintnote # XXX kbaker's hacks for BCOP
 from datetime import datetime, timedelta
 #import pytz
 
-
+logging.basicConfig()
 
 
 def display(cal):

--- a/icalendar/xmaintnote.py
+++ b/icalendar/xmaintnote.py
@@ -1,3 +1,5 @@
+import logging
+
 import icalendar
 from icalendar import Event, vText
 
@@ -6,7 +8,8 @@ try:
 except ImportError:
     import json as _json
 
-import re
+LOGGER = logging.getLogger(__name__)
+
 
 class XMaintNoteEvent(Event):
 
@@ -57,15 +60,13 @@ class vXMaintNoteImpact(vText):
         'OUTAGE'
     ]
 
-    # create a regex to check incoming types against
-    MAINT_NOTE_IMPACT = re.compile('(?:%s)' % '|'.join(impact_types))
-
     def __init__(self, *args, **kwargs):
         super(vXMaintNoteImpact, self).__init__(*args, **kwargs)
 
-        match = vXMaintNoteImpact.MAINT_NOTE_IMPACT.match(self)
-        if match is None:
-            raise ValueError('Expected x-maint-note-impact, got: %s' % self)
+        if str(self) not in self.impact_types:
+            LOGGER.debug(
+                'Unrecognised impact type %r should be treated as OUTAGE',
+                str(self))
 
 
 # tell the TypesFactory about vXMaintNoteImpact


### PR DESCRIPTION
As per the specification, custom impact values should be allowed, and it is up to the application to
determine how these are handled.

Replace the exception with a log message to indicate that an unknown
impact type was detected.
